### PR TITLE
Fix: Serve frontend/index.html at the root path

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, send_from_directory
 import os
 from .extensions import db, migrate
 # Ensure models are imported so Alembic can find them if not already by relationships
@@ -32,6 +32,10 @@ def create_app():
     app.register_blueprint(products_bp)
     app.register_blueprint(users_bp)
     app.register_blueprint(cart_bp)
+
+    @app.route('/')
+    def serve_index():
+        return send_from_directory(os.path.join(os.path.dirname(__file__), '..', 'frontend'), 'index.html')
 
     return app
 


### PR DESCRIPTION
Previously, accessing the root path ("/") resulted in a 404 error because no route was defined for it.

This change modifies `backend/app.py` to add a new route for "/". This route now serves the `frontend/index.html` file, allowing you to access the main page of the application when navigating to the root URL.