### PR TITLE
Fix: Resolve duplicate endpoint for get_product

### DIFF
--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -111,29 +111,6 @@ def get_product(product_id):
                 'name': product.name,
                 'price': product.price,
                 'description': product.description,
-                'category': product.category
-            }), 200
-        else:
-            return jsonify({'error': 'Product not found'}), 404
-    except Exception as e:
-        # Log the exception e for debugging
-        print(f"Error in get_products: {e}")
-        return jsonify({'error': 'Internal server error while retrieving products.'}), 500
-
-# Route to get a single product by ID
-@products_bp.route('/<int:product_id>', methods=['GET'])
-def get_product(product_id):
-    try:
-        # Using .get_or_404() is a Flask-SQLAlchemy shortcut for fetching or returning 404
-        # product = Product.query.get_or_404(product_id) 
-        # However, to customize the 404 JSON response, manual check is better.
-        product = Product.query.get(product_id)
-        if product:
-            return jsonify({
-                'id': product.id,
-                'name': product.name,
-                'price': product.price,
-                'description': product.description,
                 'category': product.category,
                 'subcategory': product.subcategory, # Added new field
                 'color': product.color, # Added new field


### PR DESCRIPTION
Removes a duplicate route definition for `GET /api/products/<int:product_id>`. The `AssertionError: View function mapping is overwriting an existing endpoint function: products_bp.get_product` was caused by two Flask route handlers being defined with the same HTTP method, URL rule, and endpoint name (`get_product`).

The first, less complete definition was removed, retaining the second definition which includes more fields in the product JSON response (subcategory, color, country_of_origin). This resolves the conflict and ensures the application can start correctly.